### PR TITLE
fix: `code_interface` actions accept `@context` for `Ash 2.0`

### DIFF
--- a/lib/ash/changeset/changeset.ex
+++ b/lib/ash/changeset/changeset.ex
@@ -899,6 +899,10 @@ defmodule Ash.Changeset do
     tenant: [
       type: :any,
       doc: "set the tenant on the changeset"
+    ],
+    context: [
+      type: :map,
+      doc: "Context to set on the query, changeset, or input"
     ]
   ]
 

--- a/lib/ash/code_interface.ex
+++ b/lib/ash/code_interface.ex
@@ -453,7 +453,7 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {input_opts, opts} =
-                    Keyword.split(opts, [:input, :actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [:input, :actor, :tenant, :authorize?, :tracer, :context])
 
                   {input, input_opts} = Keyword.pop(input_opts, :input)
 
@@ -474,7 +474,7 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {query_opts, opts} =
-                    Keyword.split(opts, [:query, :actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [:query, :actor, :tenant, :authorize?, :tracer, :context])
 
                   {query, query_opts} = Keyword.pop(query_opts, :query)
 
@@ -548,7 +548,14 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {changeset_opts, opts} =
-                    Keyword.split(opts, [:changeset, :actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [
+                      :changeset,
+                      :actor,
+                      :tenant,
+                      :authorize?,
+                      :tracer,
+                      :context
+                    ])
 
                   {changeset, changeset_opts} = Keyword.pop(changeset_opts, :changeset)
 
@@ -570,7 +577,7 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {changeset_opts, opts} =
-                    Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])
 
                   changeset =
                     record
@@ -589,7 +596,7 @@ defmodule Ash.CodeInterface do
               resolve_subject =
                 quote do
                   {changeset_opts, opts} =
-                    Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer])
+                    Keyword.split(opts, [:actor, :tenant, :authorize?, :tracer, :context])
 
                   changeset =
                     record


### PR DESCRIPTION
A backport of the PR introduced via https://github.com/ash-project/ash/pull/1017

Note: this PR is an attempt to debug a certain behaviour when we use the currently latest version of Ash 2.0 (6e2e40dece35966d5d67bcdc079403eda5ff5320)

When we use the latest version of Ash 2.0, calculations using an `exists` do not behave as expected.

<img width="902" alt="image" src="https://github.com/traveltechdeluxe/ash/assets/1180239/198f575d-7041-42e3-bf5e-9a244bd87374">

<img width="447" alt="image" src="https://github.com/traveltechdeluxe/ash/assets/1180239/5a0f8c12-ec2e-40f7-897b-6ca8703498c0">

![image](https://github.com/traveltechdeluxe/ash/assets/1180239/f7de12fc-83af-417c-9637-ce7b066bdd05)


This PR is an attempt to test who the calculation behaves:
- branched out from the last known "good" version we used (https://github.com/ash-project/ash/commit/9619c2fbda1e961ff9238484bf7b7d4200596301)
- cherry-picked the fix as introduced in https://github.com/ash-project/ash/commit/6e2e40dece35966d5d67bcdc079403eda5ff5320